### PR TITLE
Fix/ci workflows uv package installation

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,5 @@
 name: codecov
+
 on:
   pull_request:
   push:
@@ -15,21 +16,30 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12"]
+
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install dependencies
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      - name: Setup virtual environment and install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install ecos
+          uv venv
+          uv pip install -e ".[dev]"
+          uv pip install ecos pytest pytest-cov
+
       - name: Generate coverage report
         run: |
-          pip install pytest pytest-cov
-          pytest --cov=./ --cov-report=xml
+          uv run pytest --cov=./ --cov-report=xml
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   codecov:
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4  # Update from v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -41,7 +41,7 @@ jobs:
           uv run pytest --cov=./ --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4  # Update from v3
         with:
           files: ./coverage.xml
           fail_ci_if_error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,9 @@ name: pytest
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 jobs:
   pytest:
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,21 +26,18 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-      - name: Install dependencies
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+      - name: Setup virtual environment and install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install pytest isort black flake8
-          pip install ecos
+          uv venv
+          uv pip install -e ".[dev]"
+          uv pip install ecos pytest
       - name: Test with pytest
         run: |
-          pytest ./tests
-      - name: Check with isort
+          uv run pytest ./tests
+      - name: Check with ruff
         run: |
-          isort --check --diff .
-      - name: Check with black
-        run: |
-          black --check --diff .
-      - name: Check with flake8
-        run: |
-          flake8 --show-source --statistics .
+          uv run ruff check .


### PR DESCRIPTION
## Critical CI Issues Resolved:

### Issue: ModuleNotFoundError: No module named 'mcportfolio'
- Root Cause: CI workflows not installing mcportfolio as a package
- Solution: Use 'uv pip install -e \".[dev]\"' to install package properly

### Workflow Updates:

#### codecov.yml:
- Updated to use uv instead of pip + requirements.txt
- Added proper package installation with -e \".[dev]\"
- Updated action versions (checkout@v4, codecov@v4)
- Changed branch reference from master to main

#### main.yml:
- Updated to use uv instead of pip + requirements.txt
- Added proper package installation with -e \".[dev]\"
- Simplified Python version matrix to only 3.12
- Replaced black/flake8/isort with ruff
- Changed branch reference from master to main

## Impact:
- Resolves ModuleNotFoundError in CI tests
- Enables successful CI pipeline execution
- Modern tooling with uv package manager
- Faster CI runs with simplified matrix

Fixes: Persistent CI check failures due to module import issues"