### PR TITLE
fixes the warning by ensuring that for pull requests, the image is lo…

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,10 +64,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
-          # Add provenance setting to fix the warning
+          platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || '' }}
           provenance: ${{ github.event_name != 'pull_request' }}
-          # For pull requests, load the image instead of pushing
           load: ${{ github.event_name == 'pull_request' }}
 
       # Test Docker image if not pushing (PR context)


### PR DESCRIPTION
…aded into Docker instead of being left only in the build cache