### PR TITLE
fix: use PAT token instead of GITHUB_TOKEN for Docker registry login

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.PAT }}
           logout: false
 
       # Extract metadata (tags, labels) for Docker


### PR DESCRIPTION
- Replace secrets.GITHUB_TOKEN with secrets.PAT for enhanced permissions
- Ensures proper authentication with GitHub Container Registry
- Maintains compatibility with existing workflow structure